### PR TITLE
Fix path for dotnet

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -16,7 +16,7 @@ let projects  =
 
 
 let dotnetcliVersion = "1.0.1"
-let mutable dotnetExePath = "dotnet"
+let mutable dotnetExePath = "./dotnetsdk/dotnet"
 
 let runDotnet workingDir args =
     printfn "CWD: %s" workingDir


### PR DESCRIPTION
Current version, always download dotnet even if the right version is installed locally.