### PR TITLE
Remove console method calls

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -30,7 +30,7 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
-  <Target Name="PaketRestore" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
 
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
@@ -38,9 +38,24 @@
       <NoWarn>$(NoWarn);NU1603</NoWarn>
     </PropertyGroup>
 
+    <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
+    <PropertyGroup>
+        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+    </PropertyGroup>
+
+    <!-- If shasum and awk exist get the hashes -->
+    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    </Exec>
+    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    </Exec>
+
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
-      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
-      <PaketRestoreLockFileHash>$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
+      <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash Condition=" '$(PaketRestoreLockFileHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
@@ -88,7 +103,7 @@
     <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' " Text="A paket file for the framework '$(TargetFramework)' is missing. Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
     <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
@@ -136,22 +151,29 @@
   </Target>
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <ItemGroup>
+      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+    </ItemGroup>
+
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
       <UseNewPack>false</UseNewPack>
       <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuspecFiles Include="$(BaseIntermediateOutputPath)*.nuspec"/>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.nuspec"/>
     </ItemGroup>
 
     <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
+    </ConvertToAbsolutePath>      
+        
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"
@@ -188,7 +210,7 @@
               Serviceable="$(Serviceable)"
               FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"
@@ -230,7 +252,7 @@
               Serviceable="$(Serviceable)"
               AssemblyReferences="@(_References)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"

--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -90,9 +90,9 @@ module Cmd =
     open Fable.PowerPack
 
     /// Command to call `promise` block and map the results
-    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>) 
-                  (arg:'a) 
-                  (ofSuccess: _ -> 'msg) 
+    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>)
+                  (arg:'a)
+                  (ofSuccess: _ -> 'msg)
                   (ofError: _ -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             task arg

--- a/src/program.fs
+++ b/src/program.fs
@@ -29,8 +29,8 @@ module Program =
     let internal onError (text: string, ex: exn) = console.error (text,ex)
 
     /// Typical program, new commands are produced by `init` and `update` along with the new state.
-    let mkProgram 
-        (init : 'arg -> 'model * Cmd<'msg>) 
+    let mkProgram
+        (init : 'arg -> 'model * Cmd<'msg>)
         (update : 'msg -> 'model -> 'model * Cmd<'msg>)
         (view : 'model -> Dispatch<'msg> -> 'view) =
         { init = init
@@ -41,8 +41,8 @@ module Program =
           onError = onError }
 
     /// Simple program that produces only new state with `init` and `update`.
-    let mkSimple 
-        (init : 'arg -> 'model) 
+    let mkSimple
+        (init : 'arg -> 'model)
         (update : 'msg -> 'model -> 'model)
         (view : 'model -> Dispatch<'msg> -> 'view) =
         { init = init >> fun state -> state,Cmd.none
@@ -75,7 +75,7 @@ module Program =
             newModel,cmd
 
         { program with
-            init = traceInit 
+            init = traceInit
             update = traceUpdate }
 
     /// Trace all the messages as they update the model

--- a/src/program.fs
+++ b/src/program.fs
@@ -23,10 +23,11 @@ type Program<'arg, 'model, 'msg, 'view> = {
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Program =
-    open Fable.Core.JsInterop
-    open Fable.Import.JS
+    let internal onError (text: string, ex: exn) =
+        Console.Error.WriteLine("{0} {1}", text, ex)
 
-    let internal onError (text: string, ex: exn) = console.error (text,ex)
+    let internal write text (o : #obj) =
+        Console.WriteLine("{0}: {1}", text, o)
 
     /// Typical program, new commands are produced by `init` and `update` along with the new state.
     let mkProgram
@@ -62,16 +63,15 @@ module Program =
 
     /// Trace all the updates to the console
     let withConsoleTrace (program: Program<'arg, 'model, 'msg, 'view>) =
-        let inline toPlain o = toJson o |> JSON.parse
         let traceInit (arg:'arg) =
             let initModel,cmd = program.init arg
-            console.log ("Initial state:", toPlain initModel)
+            write "Initial state" initModel
             initModel,cmd
 
         let traceUpdate msg model =
-            console.log ("New message:", toPlain msg)
+            write "New message" msg
             let newModel,cmd = program.update msg model
-            console.log ("Updated state:", toPlain newModel)
+            write "Updated state" newModel
             newModel,cmd
 
         { program with


### PR DESCRIPTION
This pull requests removes calls to console.log and console.error from program.fs.

It does not fully remove the Fable dependency so that the `ofPromise` function can remain; a trade off which allows Elmish to be used in none Fable contexts, but recognizes that it is still primarily a Fable project.