### PR TITLE
Invert dispatch and model parameters in view

### DIFF
--- a/docs/content/basics.fsx
+++ b/docs/content/basics.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
 #I "../../src/bin/Debug/netstandard1.6"
 
@@ -12,19 +12,19 @@ First, let's import our dependencies. In a real application, these imports will 
 #r "Fable.Elmish.dll"
 
 
-(** 
+(**
 Let's define our `Model` and `Msg` types. `Model` will hold the current state and `Msg` will tell us the nature of the change that we need to apply to the current state.
 *)
 
 type Model =
     { x : int }
 
-type Msg = 
+type Msg =
     | Increment
     | Decrement
 
 
-(** 
+(**
 Now we define the `init` function that will produce initial state once the program starts running.
 It can take any arguments, but we'll just use `unit`. We'll need the [`Cmd`](cmd.html) type, so we'll open Elmish for that:
 *)
@@ -33,7 +33,7 @@ open Elmish
 let init () =
     { x = 0 }, Cmd.ofMsg Increment
 
-(** 
+(**
 Notice that we return a tuple. The first field of the tuple tells the program the initial state. The second field holds the command to issue an `Increment` message.
 
 The `update` function will receive the change required by `Msg`, and the current state. It will produce a new state and potentially new command(s).
@@ -42,26 +42,26 @@ The `update` function will receive the change required by `Msg`, and the current
 
 let update msg model =
     match msg with
-    | Increment when model.x < 3 -> 
+    | Increment when model.x < 3 ->
         { model with x = model.x + 1 }, Cmd.ofMsg Increment
-    
-    | Increment -> 
+
+    | Increment ->
         { model with x = model.x + 1 }, Cmd.ofMsg Decrement
-    
-    | Decrement when model.x > 0 -> 
+
+    | Decrement when model.x > 0 ->
         { model with x = model.x - 1 }, Cmd.ofMsg Decrement
-    
-    | Decrement -> 
+
+    | Decrement ->
         { model with x = model.x - 1 }, Cmd.ofMsg Increment
 
-(** 
-Again we return a tuple: new state, command. 
+(**
+Again we return a tuple: new state, command.
 
 If we execute this as Elmish program, it will keep updating the model from 0 to 3 and back, printing the current state to the console:
 
 *)
 
-Program.mkProgram init update (fun model _ -> printf "%A\n" model)
+Program.mkProgram init update (fun _ model -> printf "%A\n" model)
 |> Program.run
 
 

--- a/docs/content/cmd.fsx
+++ b/docs/content/cmd.fsx
@@ -15,8 +15,6 @@ Core abstractions for dispatching messages in Elmish.
 
 namespace Elmish
 
-open System
-
 /// Dispatch - feed new message into the processing loop
 type Dispatch<'msg> = 'msg -> unit
 
@@ -47,9 +45,9 @@ module Cmd =
 
     /// Command that will evaluate an async block and map the result
     /// into success or error (of exception)
-    let ofAsync (task: 'a -> Async<_>) 
-                (arg: 'a) 
-                (ofSuccess: _ -> 'msg) 
+    let ofAsync (task: 'a -> Async<_>)
+                (arg: 'a)
+                (ofSuccess: _ -> 'msg)
                 (ofError: _ -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             async {
@@ -98,9 +96,9 @@ module Cmd =
     open Fable.PowerPack
 
     /// Command to call `promise` block and map the results
-    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>) 
-                  (arg:'a) 
-                  (ofSuccess: _ -> 'msg) 
+    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>)
+                  (arg:'a)
+                  (ofSuccess: _ -> 'msg)
                   (ofError: _ -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             task arg

--- a/docs/content/parent-child.fsx
+++ b/docs/content/parent-child.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
 #I "../../src/bin/Debug/netstandard1.6"
 #r "Fable.Elmish.dll"
@@ -28,14 +28,14 @@ module Counter =
 
     let update msg model =
         match msg with
-        | Increment -> 
+        | Increment ->
             { model with count = model.count + 1 }, Cmd.none
-        
-        | Decrement -> 
+
+        | Decrement ->
             { model with count = model.count - 1 }, Cmd.none
 
 
-(** 
+(**
 Now we'll define types to hold two counters `top` and `bottom`, and message cases for each counter instance:
 *)
 
@@ -48,7 +48,7 @@ type Msg =
   | Top of Counter.Msg
   | Bottom of Counter.Msg
 
-(** 
+(**
 And our initialization logic, where we ask for two counters to be initialized:
 *)
 
@@ -56,15 +56,15 @@ let init() =
     let top, topCmd = Counter.init()
     let bottom, bottomCmd = Counter.init()
     { top = top
-      bottom = bottom }, 
+      bottom = bottom },
     Cmd.batch [ Cmd.map Top topCmd
                 Cmd.map Bottom bottomCmd ]
 
-(** 
+(**
 `Cmd.map` is used to "elevate" the Counter message into the container type, using corresponding `Top`/`Bottom` case constructors as the mapping function.
 We batch the commands together to produce a single command for our entire container.
 
-Note that even though we've implemented the counter as not issuing any commands, 
+Note that even though we've implemented the counter as not issuing any commands,
 in a real application we still may want to map the commands to facilitate encapsulation - if at any point the child does emit some messages, we'll be in a position to handle them correctly.
 
 And finally our update function:
@@ -73,11 +73,11 @@ And finally our update function:
 
 let update msg model : Model * Cmd<Msg> =
   match msg with
-  | Reset -> 
+  | Reset ->
     let top, topCmd = Counter.init()
     let bottom, bottomCmd = Counter.init()
     { top = top
-      bottom = bottom }, 
+      bottom = bottom },
     Cmd.batch [ Cmd.map Top topCmd
                 Cmd.map Bottom bottomCmd ]
   | Top msg' ->
@@ -89,19 +89,19 @@ let update msg model : Model * Cmd<Msg> =
     { model with bottom = res }, Cmd.map Bottom cmd
 
 
-(** 
+(**
 Here we see how pattern matching is used to extract counter message from `Top` and `Bottom` cases into `msg'` and it's routed to the appropriate child.
 And again, we map the command issued by the child back to the container `Msg` type.
 
 This may seem like a lot of work, but what we've done is recruited the compiler to make sure that our parent-child relationship is correctly established!
 *)
 
-(** 
+(**
 And finally, we execute this as an Elmish program:
 
 *)
 
-Program.mkProgram init update (fun model _ -> printf "%A\n" model)
+Program.mkProgram init update (fun _ model -> printf "%A\n" model)
 |> Program.run
 
 

--- a/docs/content/program.fsx
+++ b/docs/content/program.fsx
@@ -15,15 +15,13 @@ Core abstractions for creating and running the dispatch loop.
 
 namespace Elmish
 
-open System
-
 /// Program type captures various aspects of program behavior
 type Program<'arg, 'model, 'msg, 'view> = {
     init : 'arg -> 'model * Cmd<'msg>
     update : 'msg -> 'model -> 'model * Cmd<'msg>
     subscribe : 'model -> Cmd<'msg>
-    view : 'model -> Dispatch<'msg> -> 'view
-    setState : 'model -> Dispatch<'msg> -> unit
+    view : Dispatch<'msg> -> 'model -> 'view
+    setState : Dispatch<'msg> -> 'model -> unit
     onError : (string*exn) -> unit
 }
 
@@ -31,32 +29,39 @@ type Program<'arg, 'model, 'msg, 'view> = {
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Program =
+    open Fable.Core
     open Fable.Core.JsInterop
     open Fable.Import.JS
 
     let internal onError (text: string, ex: exn) = console.error (text,ex)
 
     /// Typical program, new commands are produced by `init` and `update` along with the new state.
-    let mkProgram 
-        (init : 'arg -> 'model * Cmd<'msg>) 
+    let mkProgram
+        (init : 'arg -> 'model * Cmd<'msg>)
         (update : 'msg -> 'model -> 'model * Cmd<'msg>)
-        (view : 'model -> Dispatch<'msg> -> 'view) =
+        (view : Dispatch<'msg> -> 'model -> 'view) =
         { init = init
           update = update
           view = view
-          setState = fun model -> view model >> ignore
+          setState = fun dispatch ->
+            let viewWithDispatch = view dispatch
+            fun model ->
+                viewWithDispatch model |> ignore
           subscribe = fun _ -> Cmd.none
           onError = onError }
 
     /// Simple program that produces only new state with `init` and `update`.
-    let mkSimple 
-        (init : 'arg -> 'model) 
+    let mkSimple
+        (init : 'arg -> 'model)
         (update : 'msg -> 'model -> 'model)
-        (view : 'model -> Dispatch<'msg> -> 'view) =
+        (view : Dispatch<'msg> -> 'model -> 'view) =
         { init = init >> fun state -> state,Cmd.none
           update = fun msg -> update msg >> fun state -> state,Cmd.none
           view = view
-          setState = fun model -> view model >> ignore
+          setState = fun dispatch ->
+            let viewWithDispatch = view dispatch
+            fun model ->
+                viewWithDispatch model |> ignore
           subscribe = fun _ -> Cmd.none
           onError = onError }
 
@@ -83,7 +88,7 @@ module Program =
             newModel,cmd
 
         { program with
-            init = traceInit 
+            init = traceInit
             update = traceUpdate }
 
     /// Trace all the messages as they update the model
@@ -96,19 +101,24 @@ module Program =
         { program
             with onError = onError }
 
+    [<Emit("undefined")>]
+    let private undefined<'a> (): 'a = failwith "JS Only"
+
     /// Start the program loop.
     /// arg: argument to pass to the init() function.
     /// program: program created with 'mkSimple' or 'mkProgram'.
     let runWith (arg: 'arg) (program: Program<'arg, 'model, 'msg, 'view>) =
         let (model,cmd) = program.init arg
+        let mutable setState = undefined()
         let inbox = MailboxProcessor.Start(fun (mb:MailboxProcessor<'msg>) ->
+            setState <- program.setState mb.Post
             let rec loop (state:'model) =
                 async {
                     let! msg = mb.Receive()
                     let newState =
                         try
                             let (model',cmd') = program.update msg state
-                            program.setState model' mb.Post
+                            setState model'
                             cmd' |> List.iter (fun sub -> sub mb.Post)
                             model'
                         with ex ->
@@ -118,10 +128,10 @@ module Program =
                 }
             loop model
         )
-        program.setState model inbox.Post
-        let sub = 
-            try 
-                program.subscribe model 
+        setState model
+        let sub =
+            try
+                program.subscribe model
             with ex ->
                 program.onError ("Unable to subscribe:", ex)
                 Cmd.none
@@ -129,4 +139,3 @@ module Program =
 
     /// Start the dispatch loop with `unit` for the init() function.
     let run (program: Program<unit, 'model, 'msg, 'view>) = runWith () program
-

--- a/docs/content/subscriptions.fsx
+++ b/docs/content/subscriptions.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
 #I "../../src/bin/Debug/netstandard1.6"
 #r "Fable.Elmish.dll"
@@ -18,11 +18,11 @@ open System
 type Model =
     { current : DateTime }
 
-type Msg = 
+type Msg =
     | Tick of DateTime
 
 
-(** 
+(**
 This time we'll define the "simple" version of `init` and `update` functions, that don't produce commands:
 *)
 
@@ -34,7 +34,7 @@ let update msg model =
     | Tick current ->
         { model with current = current }
 
-(** 
+(**
 
 Note that "simple" is not a requirement and is just a matter of convenience for the purpose of the example!
 
@@ -45,23 +45,23 @@ open Elmish
 open Fable.Import.Browser
 
 let timer initial =
-    let sub dispatch = 
-        window.setInterval(fun _ -> 
+    let sub dispatch =
+        window.setInterval(fun _ ->
             dispatch (Tick DateTime.Now)
             , 1000) |> ignore
     Cmd.ofSub sub
 
-Program.mkSimple init update (fun model _ -> printf "%A\n" model)
+Program.mkSimple init update (fun _ model -> printf "%A\n" model)
 |> Program.withSubscription timer
 |> Program.run
 
 
-(** 
+(**
 In this example program initialization will call our subscriber (once) with inital `Model` state, passing the `dispatch` function to be called whenever an event occurs.
 However, any time you need to issue a message (for example from a callback) you can use `Cmd.ofSub`.
 *)
 
-(** 
+(**
 ### Aggregating multiple subscribers
 If you need to aggregate multiple subscriptions follow the same pattern as when implementing `init`, `update`, and `view` functions - delegate to child components to setup their own subscriptions.
 
@@ -71,12 +71,12 @@ For example:
 module Second =
     type Msg =
         | Second of int
-    
+
     type Model = int
 
     let subscribe initial =
-        let sub dispatch = 
-            window.setInterval(fun _ -> 
+        let sub dispatch =
+            window.setInterval(fun _ ->
                 dispatch (Second DateTime.Now.Second)
                 , 1000) |> ignore
         Cmd.ofSub sub
@@ -100,8 +100,8 @@ module Hour =
         hours
 
     let subscribe initial =
-        let sub dispatch = 
-            window.setInterval(fun _ -> 
+        let sub dispatch =
+            window.setInterval(fun _ ->
                 dispatch (Hour DateTime.Now.Hour)
                 , 1000*60) |> ignore
         Cmd.ofSub sub
@@ -111,7 +111,7 @@ module App =
         { seconds : Second.Model
           hours : Hour.Model }
 
-    type Msg = 
+    type Msg =
         | SecondMsg of Second.Msg
         | HourMsg of Hour.Msg
 
@@ -121,15 +121,15 @@ module App =
 
     let update msg model =
         match msg with
-        | HourMsg msg -> 
+        | HourMsg msg ->
             { model with hours = Hour.update msg model.hours }
-        | SecondMsg msg -> 
+        | SecondMsg msg ->
             { model with seconds = Second.update msg model.seconds }
 
     let subscription model =
         Cmd.batch [ Cmd.map HourMsg (Hour.subscribe model.hours)
                     Cmd.map SecondMsg (Second.subscribe model.seconds) ]
 
-    Program.mkSimple init update (fun model _ -> printf "%A\n" model)
+    Program.mkSimple init update (fun _ model -> printf "%A\n" model)
     |> Program.withSubscription subscription
     |> Program.run

--- a/src/Fable.Elmish.fsproj
+++ b/src/Fable.Elmish.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DefineConstants>$(DefineConstants);FABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cmd.fs" />

--- a/src/Fable.Elmish.fsproj
+++ b/src/Fable.Elmish.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DefineConstants>$(DefineConstants);FABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cmd.fs" />

--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -85,6 +85,7 @@ module Cmd =
     let ofSub (sub: Sub<'msg>) : Cmd<'msg> =
         [sub]
 
+#if FABLE
     open Fable.PowerPack
 
     /// Command to call `promise` block and map the results
@@ -98,3 +99,4 @@ module Cmd =
             |> Promise.catch (ofError >> dispatch)
             |> ignore
         [bind]
+#endif

--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -85,7 +85,7 @@ module Cmd =
     let ofSub (sub: Sub<'msg>) : Cmd<'msg> =
         [sub]
 
-#if FABLE
+#if FABLE_COMPILER
     open Fable.PowerPack
 
     /// Command to call `promise` block and map the results

--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -7,8 +7,6 @@ Core abstractions for dispatching messages in Elmish.
 
 namespace Elmish
 
-open System
-
 /// Dispatch - feed new message into the processing loop
 type Dispatch<'msg> = 'msg -> unit
 
@@ -39,9 +37,9 @@ module Cmd =
 
     /// Command that will evaluate an async block and map the result
     /// into success or error (of exception)
-    let ofAsync (task: 'a -> Async<_>) 
-                (arg: 'a) 
-                (ofSuccess: _ -> 'msg) 
+    let ofAsync (task: 'a -> Async<_>)
+                (arg: 'a)
+                (ofSuccess: _ -> 'msg)
                 (ofError: _ -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             async {
@@ -90,9 +88,9 @@ module Cmd =
     open Fable.PowerPack
 
     /// Command to call `promise` block and map the results
-    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>) 
-                  (arg:'a) 
-                  (ofSuccess: _ -> 'msg) 
+    let ofPromise (task: 'a -> Fable.Import.JS.Promise<_>)
+                  (arg:'a)
+                  (ofSuccess: _ -> 'msg)
                   (ofError: _ -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             task arg

--- a/src/program.fs
+++ b/src/program.fs
@@ -29,8 +29,8 @@ module Program =
     let internal onError (text: string, ex: exn) = console.error (text,ex)
     let internal logOnConsole(text: string, o: obj) = console.log(text, toJson o |> JSON.parse)
 
-    [<Emit("undefined")>]
-    let private undefined<'a> (): 'a = failwith "JS Only"
+    [<Emit("$0==$1")>]
+    let private weakEqual a b = jsNative
 #elseif NETSTANDARD2_0
     let internal onError (text: string, ex: exn) = System.Diagnostics.Trace.TraceError("{0}: {1}", text, ex)
     let internal logOnConsole(text: string, o: obj) = printfn "%s: %A" text o
@@ -108,7 +108,7 @@ module Program =
     type private CachedValue<'a>() =
         [<DefaultValue>] val mutable Value:'a
         member this.SetValue(generator: unit ->'a) =
-            if obj.ReferenceEquals(this.Value, undefined<'a>()) then
+            if weakEqual this.Value null then
                 this.Value <- generator ()
 #else
     type private CachedValue<'a>() =

--- a/src/program.fs
+++ b/src/program.fs
@@ -31,12 +31,14 @@ module Program =
 
     [<Emit("$0==$1")>]
     let private weakEqual a b = jsNative
-#elseif NETSTANDARD2_0
+#else
+#if NETSTANDARD2_0
     let internal onError (text: string, ex: exn) = System.Diagnostics.Trace.TraceError("{0}: {1}", text, ex)
     let internal logOnConsole(text: string, o: obj) = printfn "%s: %A" text o
 #else
     let internal onError (text: string, ex: exn) = System.Console.Error.WriteLine("{0}: {1}", text, ex)
     let internal logOnConsole(text: string, o: obj) = printfn "%s: %A" text o
+#endif
 #endif
 
     /// Typical program, new commands are produced by `init` and `update` along with the new state.


### PR DESCRIPTION
Also call `view dispatch` only once allowing the view to optimize for this case.

Implement the suggestion in #130 

The result can be seen [with this small repro in the REPL](http://fable.io/repl/#?code=open%20Fable.Core%0D%0A%0D%0Aopen%20System%0D%0A%0D%0Atype%20Dispatch%3C'msg%3E%20%3D%20'msg%20-%3E%20unit%0D%0A%0D%0A%2F%2F%2F%20Subscription%20-%20return%20immediately%2C%20but%20may%20schedule%20dispatch%20of%20a%20message%20at%20any%20time%0D%0Atype%20Sub%3C'msg%3E%20%3D%20Dispatch%3C'msg%3E%20-%3E%20unit%0D%0A%0D%0A%2F%2F%2F%20Cmd%20-%20container%20for%20subscriptions%20that%20may%20produce%20messages%0D%0Atype%20Cmd%3C'msg%3E%20%3D%20Sub%3C'msg%3E%20list%0D%0A%0D%0A%2F%2F%2F%20Cmd%20module%20for%20creating%20and%20manipulating%20commands%0D%0A%5B%3CRequireQualifiedAccess%3E%5D%0D%0Amodule%20Cmd%20%3D%0D%0A%20%20%20%20%2F%2F%2F%20None%20-%20no%20commands%2C%20also%20known%20as%20%60%5B%5D%60%0D%0A%20%20%20%20let%20none%20%3A%20Cmd%3C'msg%3E%20%3D%0D%0A%20%20%20%20%20%20%20%20%5B%5D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Command%20to%20issue%20a%20specific%20message%0D%0A%20%20%20%20let%20ofMsg%20(msg%3A'msg)%20%3A%20Cmd%3C'msg%3E%20%3D%0D%0A%20%20%20%20%20%20%20%20%5Bfun%20dispatch%20-%3E%20dispatch%20msg%5D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20When%20emitting%20the%20message%2C%20map%20to%20another%20type%0D%0A%20%20%20%20let%20map%20(f%3A%20'a%20-%3E%20'msg)%20(cmd%3A%20Cmd%3C'a%3E)%20%3A%20Cmd%3C'msg%3E%20%3D%0D%0A%20%20%20%20%20%20%20%20cmd%20%7C%3E%20List.map%20(fun%20g%20-%3E%20(fun%20dispatch%20-%3E%20f%20%3E%3E%20dispatch)%20%3E%3E%20g)%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Aggregate%20multiple%20commands%0D%0A%20%20%20%20let%20batch%20(cmds%3A%20%23seq%3CCmd%3C'msg%3E%3E)%20%3A%20Cmd%3C'msg%3E%20%3D%0D%0A%20%20%20%20%20%20%20%20cmds%20%7C%3E%20List.concat%0D%0A%0D%0A%2F%2F%2F%20Program%20type%20captures%20various%20aspects%20of%20program%20behavior%0D%0Atype%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E%20%3D%20%7B%0D%0A%20%20%20%20init%20%3A%20'arg%20-%3E%20'model%20*%20Cmd%3C'msg%3E%0D%0A%20%20%20%20update%20%3A%20'msg%20-%3E%20'model%20-%3E%20'model%20*%20Cmd%3C'msg%3E%0D%0A%20%20%20%20subscribe%20%3A%20'model%20-%3E%20Cmd%3C'msg%3E%0D%0A%20%20%20%20view%20%3A%20Dispatch%3C'msg%3E%20-%3E%20'model%20-%3E%20'view%0D%0A%20%20%20%20setState%20%3A%20Dispatch%3C'msg%3E%20-%3E%20'model%20-%3E%20unit%0D%0A%20%20%20%20onError%20%3A%20(string*exn)%20-%3E%20unit%0D%0A%7D%0D%0A%0D%0A%2F%2F%2F%20Program%20module%20-%20functions%20to%20manipulate%20program%20instances%0D%0A%5B%3CRequireQualifiedAccess%3E%5D%0D%0A%5B%3CCompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)%3E%5D%0D%0Amodule%20Program%20%3D%0D%0A%20%20%20%20open%20Fable.Core.JsInterop%0D%0A%20%20%20%20open%20Fable.Import.JS%0D%0A%0D%0A%20%20%20%20let%20internal%20onError%20(text%3A%20string%2C%20ex%3A%20exn)%20%3D%20console.error%20(text%2Cex)%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Typical%20program%2C%20new%20commands%20are%20produced%20by%20%60init%60%20and%20%60update%60%20along%20with%20the%20new%20state.%0D%0A%20%20%20%20let%20mkProgram%0D%0A%20%20%20%20%20%20%20%20(init%20%3A%20'arg%20-%3E%20'model%20*%20Cmd%3C'msg%3E)%0D%0A%20%20%20%20%20%20%20%20(update%20%3A%20'msg%20-%3E%20'model%20-%3E%20'model%20*%20Cmd%3C'msg%3E)%0D%0A%20%20%20%20%20%20%20%20(view%20%3A%20Dispatch%3C'msg%3E%20-%3E%20'model%20-%3E%20'view)%20%3D%0D%0A%20%20%20%20%20%20%20%20%7B%20init%20%3D%20init%0D%0A%20%20%20%20%20%20%20%20%20%20update%20%3D%20update%0D%0A%20%20%20%20%20%20%20%20%20%20view%20%3D%20view%0D%0A%20%20%20%20%20%20%20%20%20%20setState%20%3D%20fun%20dispatch%20-%3E%20view%20dispatch%20%3E%3E%20ignore%0D%0A%20%20%20%20%20%20%20%20%20%20subscribe%20%3D%20fun%20_%20-%3E%20Cmd.none%0D%0A%20%20%20%20%20%20%20%20%20%20onError%20%3D%20onError%20%7D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Simple%20program%20that%20produces%20only%20new%20state%20with%20%60init%60%20and%20%60update%60.%0D%0A%20%20%20%20let%20mkSimple%0D%0A%20%20%20%20%20%20%20%20(init%20%3A%20'arg%20-%3E%20'model)%0D%0A%20%20%20%20%20%20%20%20(update%20%3A%20'msg%20-%3E%20'model%20-%3E%20'model)%0D%0A%20%20%20%20%20%20%20%20(view%20%3A%20Dispatch%3C'msg%3E%20-%3E%20'model%20-%3E%20'view)%20%3D%0D%0A%20%20%20%20%20%20%20%20%7B%20init%20%3D%20init%20%3E%3E%20fun%20state%20-%3E%20state%2CCmd.none%0D%0A%20%20%20%20%20%20%20%20%20%20update%20%3D%20fun%20msg%20-%3E%20update%20msg%20%3E%3E%20fun%20state%20-%3E%20state%2CCmd.none%0D%0A%20%20%20%20%20%20%20%20%20%20view%20%3D%20view%0D%0A%20%20%20%20%20%20%20%20%20%20setState%20%3D%20fun%20dispatch%20-%3E%20view%20dispatch%20%3E%3E%20ignore%0D%0A%20%20%20%20%20%20%20%20%20%20subscribe%20%3D%20fun%20_%20-%3E%20Cmd.none%0D%0A%20%20%20%20%20%20%20%20%20%20onError%20%3D%20onError%20%7D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Subscribe%20to%20external%20source%20of%20events.%0D%0A%20%20%20%20%2F%2F%2F%20The%20subscription%20is%20called%20once%20-%20with%20the%20initial%20model%2C%20but%20can%20dispatch%20new%20messages%20at%20any%20time.%0D%0A%20%20%20%20let%20withSubscription%20(subscribe%20%3A%20'model%20-%3E%20Cmd%3C'msg%3E)%20(program%3A%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%0D%0A%20%20%20%20%20%20%20%20let%20sub%20model%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20Cmd.batch%20%5B%20program.subscribe%20model%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20subscribe%20model%20%5D%0D%0A%20%20%20%20%20%20%20%20%7B%20program%20with%20subscribe%20%3D%20sub%20%7D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Trace%20all%20the%20updates%20to%20the%20console%0D%0A%20%20%20%20let%20withConsoleTrace%20(program%3A%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%0D%0A%20%20%20%20%20%20%20%20let%20inline%20toPlain%20o%20%3D%20toJson%20o%20%7C%3E%20JSON.parse%0D%0A%20%20%20%20%20%20%20%20let%20traceInit%20(arg%3A'arg)%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20initModel%2Ccmd%20%3D%20program.init%20arg%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20console.log%20(%22Initial%20state%3A%22%2C%20toPlain%20initModel)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20initModel%2Ccmd%0D%0A%0D%0A%20%20%20%20%20%20%20%20let%20traceUpdate%20msg%20model%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20console.log%20(%22New%20message%3A%22%2C%20toPlain%20msg)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20newModel%2Ccmd%20%3D%20program.update%20msg%20model%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20console.log%20(%22Updated%20state%3A%22%2C%20toPlain%20newModel)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20newModel%2Ccmd%0D%0A%0D%0A%20%20%20%20%20%20%20%20%7B%20program%20with%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20init%20%3D%20traceInit%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20update%20%3D%20traceUpdate%20%7D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Trace%20all%20the%20messages%20as%20they%20update%20the%20model%0D%0A%20%20%20%20let%20withTrace%20trace%20(program%3A%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%0D%0A%20%20%20%20%20%20%20%20%7B%20program%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20with%20update%20%3D%20fun%20msg%20model%20-%3E%20trace%20msg%20model%3B%20program.update%20msg%20model%7D%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Handle%20dispatch%20loop%20exceptions%0D%0A%20%20%20%20let%20withErrorHandler%20onError%20(program%3A%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%0D%0A%20%20%20%20%20%20%20%20%7B%20program%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20with%20onError%20%3D%20onError%20%7D%0D%0A%0D%0A%20%20%20%20%5B%3CEmit(%22undefined%22)%3E%5D%0D%0A%20%20%20%20let%20private%20undefined%3C'a%3E%20()%3A%20'a%20%3D%20failwith%20%22JS%20Only%22%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Start%20the%20program%20loop.%0D%0A%20%20%20%20%2F%2F%2F%20arg%3A%20argument%20to%20pass%20to%20the%20init()%20function.%0D%0A%20%20%20%20%2F%2F%2F%20program%3A%20program%20created%20with%20'mkSimple'%20or%20'mkProgram'.%0D%0A%20%20%20%20let%20runWith%20(arg%3A%20'arg)%20(program%3A%20Program%3C'arg%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%0D%0A%20%20%20%20%20%20%20%20let%20(model%2Ccmd)%20%3D%20program.init%20arg%0D%0A%20%20%20%20%20%20%20%20let%20mutable%20setState%20%3D%20undefined()%0D%0A%20%20%20%20%20%20%20%20let%20inbox%20%3D%20MailboxProcessor.Start(fun%20(mb%3AMailboxProcessor%3C'msg%3E)%20-%3E%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20setState%20%3C-%20program.setState%20mb.Post%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20rec%20loop%20(state%3A'model)%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20async%20%7B%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let!%20msg%20%3D%20mb.Receive()%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20newState%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20try%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20(model'%2Ccmd')%20%3D%20program.update%20msg%20state%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20setState%20model'%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20cmd'%20%7C%3E%20List.iter%20(fun%20sub%20-%3E%20sub%20mb.Post)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20model'%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20with%20ex%20-%3E%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20program.onError%20(%22Unable%20to%20process%20a%20message%3A%22%2C%20ex)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20state%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return!%20loop%20newState%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20loop%20model%0D%0A%20%20%20%20%20%20%20%20)%0D%0A%20%20%20%20%20%20%20%20setState%20model%0D%0A%20%20%20%20%20%20%20%20let%20sub%20%3D%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20try%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20program.subscribe%20model%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20with%20ex%20-%3E%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20program.onError%20(%22Unable%20to%20subscribe%3A%22%2C%20ex)%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Cmd.none%0D%0A%20%20%20%20%20%20%20%20sub%20%40%20cmd%20%7C%3E%20List.iter%20(fun%20sub%20-%3E%20sub%20inbox.Post)%0D%0A%0D%0A%20%20%20%20%2F%2F%2F%20Start%20the%20dispatch%20loop%20with%20%60unit%60%20for%20the%20init()%20function.%0D%0A%20%20%20%20let%20run%20(program%3A%20Program%3Cunit%2C%20'model%2C%20'msg%2C%20'view%3E)%20%3D%20runWith%20()%20program%0D%0A%0D%0Aopen%20Fable.Import.JS%0D%0Aopen%20Fable.Import.Browser%0D%0A%0D%0Atype%20Model%20%3D%20%7B%20counter%3A%20int%7D%0D%0Atype%20Msg%20%3D%20%7C%20Increment%0D%0A%0D%0Alet%20init()%20%3D%20%7B%20counter%20%3D%20-1%20%7D%2C%20Cmd.ofMsg%20Increment%0D%0A%0D%0Alet%20update%20msg%20(model%3A%20Model)%20%3D%0D%0A%20%20%20%20match%20msg%20with%0D%0A%20%20%20%20%7C%20Increment%20-%3E%20%7B%20model%20with%20counter%20%3D%20model.counter%20%2B%201%7D%2C%20Cmd.none%0D%0A%0D%0Alet%20view%20(dispatch%3A%20Dispatch%3CMsg%3E)%20(model%3A%20Model)%20%3D%0D%0A%20%20%20%20model.counter.ToString()%0D%0A%0D%0Alet%20debugProgram%20(program%3AProgram%3C_%2C_%2C_%2C_%3E)%20%3D%0D%0A%20%20%20%20let%20setState%20dispatch%20%3D%0D%0A%20%20%20%20%20%20%20%20let%20view%20%3D%20program.view%20dispatch%0D%0A%20%20%20%20%20%20%20%20document.getElementById(%22b%22).addEventListener_click(fun%20_%20-%3E%20dispatch%20Increment%3B%20unbox%20null)%0D%0A%20%20%20%20%20%20%20%20fun%20model%20-%3E%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20document.getElementById(%22x%22).textContent%20%3C-%20view%20model%0D%0A%20%20%20%20%7B%20program%20with%20setState%20%3D%20setState%20%7D%0D%0A%0D%0AProgram.mkProgram%20init%20update%20view%0D%0A%7C%3E%20debugProgram%0D%0A%7C%3E%20Program.run%0D%0A&html=%3Chtml%3E%3Cbody%3E%0D%0A%20%20%20%20%3Cdiv%20id%3D%22x%22%3E%3C%2Fdiv%3E%0D%0A%20%20%20%20%3Cbutton%20id%3D%22b%22%3EINC%3C%2Fbutton%3E%0D%0A%20%20%20%20%3C%2Fbody%3E%3C%2Fhtml%3E), without it the event handler for the button would be added multiple times and the counter count faster and faster.

With the differences in API it's a major SemVer version change :) I'll try to go through the other repos and update them.